### PR TITLE
message-header

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,7 +24,7 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group.id), notice: 'グループを更新しました'
     else
       render :edit
     end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -2,10 +2,14 @@
   .chat-main__group-info
     .items-info
       .items-info__top-left
-        .group-name test
-        .member-list Member : masa
+        .group-name 
+          = @group.name    
+        .member-list 
+          Member :
+          - @group.users.each do |user|
+            = user.name 
       .items-info__top-right
-        = link_to "#", class: "btn-edit" do
+        = link_to edit_group_path(@group.id), class: "btn-edit" do
           .edit
             Edit
   .chat-main__message-list


### PR DESCRIPTION
#What
メッセージ機能のヘッダー部分にグループ名とメンバーの表示
右上のEditボタンを押したらグループ編集ページへ移動するように変更
グループ編集ページで更新ボタンを押した時にグループのメッセージ一覧のページへ移動するように変更

#Why
グループチャット画面を一目見ただけでグループ名とメンバーを把握できるようにするため
グループ編集ページへの移動をわかりやすくするため
わかりやすく更新後に元にいたページに戻るようにするため