### PR TITLE
[WIP]auto-update

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
     if ( message.image ) {
       var html =
-       `<div class="message">
+       `<div class="message" data-message-id=${message.id}>
           <div class="message__message-top">
             <div class="message__message-top--name">
               ${message.user_name}
@@ -21,7 +21,7 @@ $(function(){
       return html;
     } else {
       var html =
-      `<div class="message">
+      `<div class="message" data-message-id=${message.id}>
       <div class="message__message-top">
         <div class="message__message-top--name">
           ${message.user_name}
@@ -62,4 +62,37 @@ $(function(){
       alert("メッセージ送信に失敗しました");
   });
   });
+  var reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+      url: "api/messages",
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+      //追加するHTMLの入れ物を作る
+      var insertHTML = '';
+      //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+      $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+      });
+      //メッセージが入ったHTMLに、入れ物ごと追加
+      $('.chat-main__message-list').append(insertHTML);
+      $('.chat-main__message-list').animate({ scrollTop: $('.chat-main__message-list')[0].scrollHeight});
+    }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+// $(function(){});の閉じタグの直上(処理の最後)に以下のように追記
+if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+  setInterval(reloadMessages, 7000);
+}
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__message-top
     .message__message-top--name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,6 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+#idもデータとして渡す
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:edit, :update, :index]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create] 
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#What
メッセージ機能の自動更新機能の追加
7秒ごとにメッセージ欄が更新されるように変更
メッセージにカスタム属性でIDを付与し、現在表示されている最新メッセージのIDよりも大きいIDのメッセージがある場合に、メッセージ欄に追記されるように変更

#Why
他人が送ったメッセージを非同期通信で自動更新されるように設定し、いちいち更新する手間をなくすため

https://gyazo.com/7a9f06bce9d73e21ad2ff364b1cb8975
